### PR TITLE
Updated tutorials to use correct environment setup

### DIFF
--- a/source/Simulation/Startsim.rst
+++ b/source/Simulation/Startsim.rst
@@ -46,8 +46,9 @@ drive the robot.   The first step is to source the setup file:
 
 ::
 
+   source /opt/ros/ardent/setup.bash
    cd <veranda directory>
-   source setup.bash
+   source local_setup.bash
    python3 Scripts/fig8_differential.py
 
 This should drive the robot in a figure 8 shaped path.   You will see other

--- a/source/Simulation/VerandaTutorial.rst
+++ b/source/Simulation/VerandaTutorial.rst
@@ -3,7 +3,7 @@ Tutorial: Simulating with Veranda
 
 This section of the book will walk you through the entire process
 of designing your own robot and programming it to drive and produce
-sensor feedback.
+sensor feedback. The tutorial assumes you have ROS installed in the default location: ``/opt/ros/ardent``.
 
 Part 0: Install and Run Veranda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,7 +238,8 @@ step, because we need to set up the ROS environment first.
 
 .. code:: bash
 
-    > source ~/veranda/install/setup.bash
+    > source /opt/ros/ardent/setup.bash
+    > source ~/veranda/local_setup.bash
     > export RMW_IMPLEMENTATION=rmw_opensplice_cpp
     > python3 circle.py
 
@@ -247,7 +248,7 @@ to send and receive messages, you can stop it with ``Ctrl-C``
 
 .. TIP::
 
-    You don't need to do ``source ~/veranda/install/setup.bash`` and ``export RMW_IMPLEMENTATION=rmw_opensplice_cpp`` every time you run your code, just the first time. After you have
+    You don't need to do the two ``source [path]`` commands and the ``export RMW_IMPLEMENTATION`` every time you run your code, just the first time. After you have
     sourced the environment for a specific terminal, those environment variables will stay set up!
 
 .. IMPORTANT::


### PR DESCRIPTION
Switched tutorials to tell the students to source ros, and then local…_setup instead of just setup because setup.bash had fully-qualified paths expected based on the build machine